### PR TITLE
Rename .call due to ambiguity with Function.prototype.call

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -92,7 +92,7 @@ var client = function (config) {
 		 * @param query
 		 * @param callback
 		 */
-		config.call = function (action, query, callback) {
+		config.request = function (action, query, callback) {
 			if ( ! callback) {
 				callback = query;
 				query = {};
@@ -123,6 +123,11 @@ var client = function (config) {
 					'content-type': 'application/x-www-form-urlencoded; charset=utf-8'
 				})
 			}, qs.stringify(query), 'xml', callback);
+		};
+		config.call = function() {
+			// This is deprecated due to ambiguity with Function.prototype.call.
+			console.error('Warning: aws2js use of .call() is deprecated.  Use .request() instead.');
+			return config.request.apply(this, arguments);
 		};
 	}
 	/* in use by the S3 REST API */


### PR DESCRIPTION
(I need to figure out how to do pull requests properly.  Sorry about the duplicate issue.)

Great work on refactoring/rewriting aws-lib and all the effort to add documentation. I love it.

One holdover from aws-lib that might be nice to remove is the naming of the main "call" function. It looks a little ambiguous as many JS developers are used to using Function.prototype.call to pass context to a function.

I propose renaming this to "request" (though there may be a better name). The "call" function still works, though it outputs a warning message to console.error.

I'm attaching a pull request on the future branch with the proposed change.

Thanks!
