### PR TITLE
Clone aws clients

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -481,13 +481,21 @@ var client = function (config) {
  * @param secretAccessKey
  */
 exports.load = function (cl, accessKeyId, secretAccessKey) {
-	var clients = cfg.clients;
-	if ( ! clients[cl]) {
-		throw new Error('Invalid AWS client');
-	}
-	cl = client(clients[cl]);
-	if (accessKeyId && secretAccessKey) {
-		cl.setCredentials(accessKeyId, secretAccessKey);
-	}
-	return cl;
+  var clientTemplate = cfg.clients[cl];
+  if ( ! clientTemplate) {
+    throw new Error('Invalid AWS client');
+  }
+
+  var result = client({
+    host : clientTemplate.host,
+    prefix : clientTemplate.prefix,
+    path : clientTemplate.host,
+    query : clientTemplate.query
+  });
+
+  if (accessKeyId && secretAccessKey) {
+    result.setCredentials(accessKeyId, secretAccessKey);
+  }
+  
+  return result;
 };


### PR DESCRIPTION
Hi

This is a small change that clones a client each time one is loaded.

This is required for SQS because each time you call setQueue on a config, it overwrites the path of the config. So, if I try to interact with two queues from the same node instance, they conflict without this.

Cheers
- Dave
