### PR TITLE
added optional query parameter to s3.get

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -206,10 +206,16 @@ var client = function (config) {
 		/**
 		 * Wraps the GET requests to the S3 API
 		 * @param path
+		 * @param query
 		 * @param handler
 		 * @param callback
 		 */
-		config.get = function (path, handler, callback) {
+		config.get = function (path, query, handler, callback) {
+			if (!callback) {
+				callback = handler;
+				handler = query;
+				query = {};
+			}
 			internals.checkConfig(config);
 			path = internals.checkPath(path, callback);
 			if ( ! path) {
@@ -219,9 +225,10 @@ var client = function (config) {
 					if (err) {
 						callback(err);
 					} else {
+						var s = qs.stringify(query);
 						internals.makeRequest(config, {
 							method: 'GET',
-							path: path,
+							path: s ? path+ '?'+ s : path,
 							headers: headers
 						}, false, handler, callback)
 					}
@@ -622,7 +629,7 @@ var client = function (config) {
 				config.put(path + '?partNumber=' + partNumber + '&uploadId=' + uploadId, headers, fileHandler, function (err, res) {
 					if (err) {
 						err.partNumber = partNumber;
-						callback(err) 
+						callback(err);
 					} else {
 						callback(null, {
 							partNumber: partNumber,


### PR DESCRIPTION
In order to page through the list of objects in a bucket, it is necessary to pass parameters to `GET`

As far as I could see, this is not possible with `s3.get` as it stands.
Appending a query string to the `path` parameter breaks authorization, and would be kludgy anyway.

So I propose adding a optional `query` parameter to `s3.get`
