### PR TITLE
Global variable leak fixed

### DIFF
--- a/lib/internals.js
+++ b/lib/internals.js
@@ -517,7 +517,7 @@ var standardHeaders = function (config, method, headers, path, body, callback) {
 	path = path.replace('%27', "'");
 	var query = tools.sortObject(qs.parse(elements.query));
 	if ( ! tools.isEmpty(query)) {
-		queryParts = [];
+		var queryParts = [];
 		for (var key in query) {
 			if (key in cfg.subResource) {
 				if (query[key]) {


### PR DESCRIPTION
Missed `var` keyword is back to prevent global variables collisions.
