### PR TITLE
Add http options client creation

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -15,11 +15,23 @@ var internals = require('./internals.js');
  * @param config
  * @return config
  */
-var client = function (config) {
+var client = function (config, httpOptions) {
 	if ( ! config.host) {
 		config.host = config.prefix + cfg.suffix;
 	}
 	/* globally accessible */
+
+	/**
+ 	 * Helper for stopping httpOptions getting polluted
+ 	 */
+	config.cloneHttpOptions = function() {
+		var result = {};
+		for (var key in httpOptions) {
+			result[key] = httpOptions[key];
+		}
+		return result;
+	};
+
 	/**
 	 * Mandatory helper for setting the credentials
 	 * @param accessKeyId
@@ -189,10 +201,10 @@ var client = function (config) {
 				var clientBody = qs.stringify(query);
 				var responseBodyHandler = 'xml';
 			}
-			internals.makeRequest(config, {
-				method: 'POST',
-				headers: tools.merge(headers, clientHeaders)
-			}, clientBody, responseBodyHandler, callback);
+			var options = config.cloneHttpOptions();
+			options.method = 'POST';
+			options.headers = tools.merge(headers, clientHeaders);
+			internals.makeRequest(config, options, clientBody, responseBodyHandler, callback);
 		};
 		config.call = function() {
 			// This is deprecated due to ambiguity with Function.prototype.call.
@@ -225,11 +237,11 @@ var client = function (config) {
 					if (err) {
 						callback(err);
 					} else {
-						internals.makeRequest(config, {
-							method: 'GET',
-							path: path,
-							headers: headers
-						}, false, handler, callback)
+						var options = config.cloneHttpOptions();
+						options.method = 'GET';
+						options.path = path;
+						options.headers = headers;
+						internals.makeRequest(config, options, false, handler, callback)
 					}
 				}
 			);
@@ -249,11 +261,11 @@ var client = function (config) {
 					if (err) {
 						callback(err);
 					} else {
-						internals.makeRequest(config, {
-							method: 'HEAD',
-							path: path,
-							headers: headers
-						}, false, null, callback);
+						var options = config.cloneHttpOptions();
+						options.method = 'HEAD';
+						options.path = path;
+						options.headers = headers;
+						internals.makeRequest(config, options, false, null, callback);
 					}
 				}
 			);
@@ -275,11 +287,11 @@ var client = function (config) {
 					if (err) {
 						callback(err);
 					} else {
-						internals.makeRequest(config, {
-							method: 'DELETE',
-							path: path,
-							headers: headers
-						}, false, null, callback);
+						var options = config.cloneHttpOptions();
+						options.method = 'DELETE';
+						options.path = path;
+						options.headers = headers;
+						internals.makeRequest(config, options, false, null, callback);
 					}
 				}
 			);
@@ -307,11 +319,11 @@ var client = function (config) {
 					if (err) {
 						callback(err);
 					} else {
-						internals.makeRequest(config, {
-							method: 'PUT',
-							path: path,
-							headers: hdrs
-						}, body, null, callback);
+						var options = config.cloneHttpOptions();
+						options.method = 'PUT';
+						options.path = path;
+						options.headers = hdrs;
+						internals.makeRequest(config, options, body, null, callback);
 					}
 				}
 			);
@@ -337,11 +349,11 @@ var client = function (config) {
 						callback(err);
 					} else {
 						hdrs.expect = '100-continue';
-						internals.makeRequest(config, {
-							method: 'POST',
-							path: path,
-							headers: hdrs
-						}, body, 'xml', callback);
+						var options = config.cloneHttpOptions();
+						options.method = 'POST';
+						options.path = path;
+						options.headers = hdrs;
+						internals.makeRequest(config, options, body, 'xml', callback);
 					}
 				}
 			);
@@ -790,8 +802,11 @@ var client = function (config) {
  * @param service
  * @param accessKeyId
  * @param secretAccessKey
+ * @param sessionToken
+ * @param httpOptions
  */
-exports.load = function (service, accessKeyId, secretAccessKey, sessionToken) {
+exports.load = function (service, accessKeyId, secretAccessKey, sessionToken, httpOptions) {
+
 	if (service == 's3') {
 		if (process.version == 'v0.6.9') { // npm doesn't like version ranges, the parser is FUBAR
 			throw new Error('FATAL: The S3 client is NOT supported under node.js v0.6.9.');
@@ -809,7 +824,7 @@ exports.load = function (service, accessKeyId, secretAccessKey, sessionToken) {
 	for (var key in clientTemplate) {
 		clientConfig[key] = clientTemplate[key];
 	}
-	var result = client(clientConfig);
+	var result = client(clientConfig, httpOptions || {});
 	if (accessKeyId && secretAccessKey) {
 		result.setCredentials(accessKeyId, secretAccessKey, sessionToken);
 	}

--- a/lib/internals.js
+++ b/lib/internals.js
@@ -250,10 +250,15 @@ var makeRequest = function (config, options, body, handler, callback, requestId)
 			});
 			response.on('close', function () {
 				if ( ! aborted) {
-					var error = new Error('The server prematurely closed the connection.');
-					error.headers = response.headers;
-					error.code = response.statusCode;
-					callback(error);
+					if (data.length > 0) {
+						// Try parsing the data we have - most often it seems to be a well-formed response
+						parseXml(data);
+					} else {
+						var error = new Error('The server prematurely closed the connection and there was no data.');
+						error.headers = response.headers;
+						error.code = response.statusCode;
+						callback(error);
+					}
 				}
 			});
 		}


### PR DESCRIPTION
Hi,

here's a couple of changes to aws2js. One is to allow me to pass html options into the client load routine. The motivation for me was so that I can say "agent : false" to avoid problems with http connection pooling.

The other is a small change to the handling of dropped connections. We seem to see a number of these when doing SQS ReceiveMessage, and in every case, we've actually already got a whole message from Amazon which we'd like to process. This seems a fairly safe change: if we haven't got a whole message the XML parse won't work out so we're unlikely to do anything bad.
