### PR TITLE
Bug with Headers

### DIFF
--- a/lib/internals.js
+++ b/lib/internals.js
@@ -471,7 +471,10 @@ var authorize = function (config, method, headers, path) {
 	keys = keys.sort();
 	for (var n in keys) {
 		var key = keys[n];
-		sorted[key] = headers[key].trim();
+
+		if(headers[key]){
+			sorted[key] = headers[key].trim();	
+		}
 	}
 	for (var key in sorted) {
 		toSign += key + ':' + sorted[key] + '\n';


### PR DESCRIPTION
Don't know why I got this 

```
TypeError: Cannot call method 'trim' of undefined
    at /Users/johnny/Documents/tactivos/murally/node_modules/aws2js/lib/internals.js:474:30
    at Object.standardHeaders (/Users/johnny/Documents/tactivos/murally/node_modules/aws2js/lib/internals.js:565:22)
    at Object.get (/Users/johnny/Documents/tactivos/murally/node_modules/aws2js/lib/aws.js:234:14)
    at Function.get (/Users/johnny/Documents/tactivos/murally/lib/boardStorage.js:8:5)
    at Promise.<anonymous> (/Users/johnny/Documents/tactivos/murally/lib/boardrepository.js:25:11)
    at Promise.<anonymous> (/Users/johnny/Documents/tactivos/murally/node_modules/mongoose/lib/promise.js:120:8)
    at Promise.<anonymous> (events.js:67:17)
    at Promise.emit (/Users/johnny/Documents/tactivos/murally/node_modules/mongoose/lib/promise.js:59:38)
    at Promise.complete (/Users/johnny/Documents/tactivos/murally/node_modules/mongoose/lib/promise.js:70:20)
    at /Users/johnny/Documents/tactivos/murally/node_modules/mongoose/lib/query.js:919:15
```

With this pull request it gets fixed
