### PR TITLE
Add S3 lifecycle configuration management

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -9,6 +9,7 @@ var qs = require('querystring');
 var cfg = require('./config.js');
 var tools = require('./tools.js');
 var internals = require('./internals.js');
+var libxmljs = require('libxmljs');
 
 /**
  * The client itself
@@ -570,6 +571,156 @@ var client = function (config, httpOptions) {
 				}
 			});
 		};
+
+        /**
+         * Get the bucket lifecycle configuration.
+         * Returns a 400 error if the bucket has no
+         * lifecycle configuration (S3 behaviour).
+         * @param callback
+         */
+        config.getLifeCycle = function(callback)  {
+            internals.checkConfig(config);
+            config.get('?lifecycle', 'xml', function(error, response) {
+                callback(error, response);
+            })
+        };
+        /**
+         * Delete the bucket lifecycle configuration
+         * @param callback
+         */
+        config.delLifeCycle = function(callback) {
+            internals.checkConfig(config);
+            config.del('?lifecycle', function(error, response) {
+                callback(error, response);
+            })
+        };
+        // find the rule according to the rule id
+        // returns the rule and its index in the array
+        // to facilitate the splice() if needed.
+        function findLifeCycleRule(id, lifecycle) {
+            if (Object.prototype.toString.call( lifecycle.Rule ) !== '[object Array]') {
+                // When there is only one rule, response.Rule is not interpreted
+                // as an array by libxml-to-js. We transform it to an array to
+                // simplify the process below
+                lifecycle.Rule = [ lifecycle.Rule ];
+            }
+            var existingRules = lifecycle.Rule;
+            for (var i = 0; i < existingRules.length; i++) {
+                if (existingRules[i].ID == id) {
+                    return {
+                        index: i,
+                        rule: existingRules[i]
+                    };
+                }
+            }
+        }
+        // common method for put and del
+        // serialize the lifecycle config to xml
+        function putLifeCycleConfig(lifecycle, callback) {
+            // Serialize response object to xml
+            var document = new libxmljs.Document().node('LifecycleConfiguration');
+            for (var i = 0; i < lifecycle.Rule.length; i++) {
+                document.node('Rule').
+                        node('ID', lifecycle.Rule[i].ID).parent().
+                        node('Prefix', lifecycle.Rule[i].Prefix).parent().
+                        node('Status', lifecycle.Rule[i].Status).parent().
+                        node('Expiration').node('Days', lifecycle.Rule[i].Expiration.Days);
+
+            }
+            var body = document.toString();
+            var headers = {};
+            var md5 = crypto.createHash('md5');
+            md5.update(body);
+            headers['content-md5'] = md5.digest('base64');
+
+            // put the new lifecycle configuration
+            config.put('?lifecycle', headers, body, function(error, response) {
+                callback(error, response);
+            });
+        }
+        /**
+         * Add a lifecycle rule to the bucket
+         * lifecycle configuration
+         * @param id
+         * @param prefix
+         * @param expireInDays
+         * @param callback
+         */
+        config.putLifeCycleRule = function(id, prefix, expireInDays, callback) {
+            internals.checkConfig(config);
+            // allow this method to have type number for expireInDays parameter
+            expireInDays = expireInDays+'';
+
+            // first retrieve existing rules
+            config.getLifeCycle(function(error, response) {
+
+                if (error) {
+                    if (error.document && error.document.Code == 'NoSuchLifecycleConfiguration') {
+                        // the bucket hasn't a lifecycle configuration, we need to create it
+                        response = { Rule: [] };
+                    } else {
+                        callback(error);
+                        return;
+                    }
+                }
+
+                // the bucket has a lifecycle configuration, we need to update it.
+                // check if the rule for the specified id already exists
+                var found = findLifeCycleRule(id, response);
+                if (found) {
+                    // the rule exists, update it
+                    var rule = found.rule;
+                    rule.Prefix = prefix;
+                    rule.Expiration.Days = expireInDays;
+                } else {
+                    // if not exists, create and add the new desired rule
+                    response.Rule.push( {
+                        ID: id,
+                        Prefix: prefix,
+                        Status: 'Enabled',
+                        Expiration: { Days: expireInDays }
+                    } );
+                }
+                // now put the new lifecycle configuration
+                putLifeCycleConfig(response, callback);
+            });
+        };
+        /**
+         * Deletes a specific rule
+         * Returns an error if the bucket hasn't lifecycle
+         * config or if the rule is not found.
+         * @param id
+         * @param callback
+         */
+        config.delLifeCycleRule = function(id, callback) {
+            internals.checkConfig(config);
+
+            // first retrieve existing rules
+            config.getLifeCycle(function(error, response) {
+                if (error) {
+                    // no rule to delete, error
+                    callback(error);
+                }
+                var found = findLifeCycleRule(id, response);
+                if (found) {
+                    // the rule exists
+                    if (response.Rule.length == 1) {
+                        // this is the only Rule of the lifecycle config
+                        // because S3 doesn't accept empty lifecycle config,
+                        // we must use the global delete
+                        config.delLifeCycle(function(error, response) {
+                            callback(error, response);
+                        });
+                        return;
+                    }
+                    // remove the rule
+                    response.Rule.splice(found.index, 1);
+                }
+                // now put the new lifecycle configuration
+                putLifeCycleConfig(response, callback);
+            })
+        };
+
 		/**
 		 * Initiates a multipart upload
 		 * @param path

--- a/tests/s3-lifecycle.js
+++ b/tests/s3-lifecycle.js
@@ -1,0 +1,38 @@
+var assert = require('assert');
+var s3 = require('../').load('s3');
+
+var callbacks = {
+    putLifeCycleRule1: false,
+    putLifeCycleRule2: false,
+    delLifeCycleRule1: false,
+    delLifeCycleRule2: false
+};
+
+s3.setCredentials(process.env.AWS_ACCEESS_KEY_ID, process.env.AWS_SECRET_ACCESS_KEY);
+s3.setBucket(process.env.AWS2JS_S3_BUCKET);
+
+s3.putLifeCycleRule('id', 'prefix', 5, function (error, response) {
+	callbacks.putLifeCycleRule1 = true;
+	assert.ifError(error);
+
+    s3.putLifeCycleRule('id2', 'otherprefix', 5, function (error, response) {
+        callbacks.putLifeCycleRule2 = true;
+        assert.ifError(error);
+
+        s3.delLifeCycleRule('id', function(error, response) {
+            callbacks.delLifeCycleRule1 = true;
+            assert.ifError(error);
+
+            s3.delLifeCycleRule('id2', function(error, response) {
+                callbacks.delLifeCycleRule2 = true;
+                assert.ifError(error);
+            });
+        });
+    });
+});
+
+process.on('exit', function () {
+	for (var i in callbacks) {
+		assert.ok(callbacks[i]);
+	}
+});


### PR DESCRIPTION
added the following methods :
- getLifeCycle : return the bucket lifcycle configuration if it has one,
  or 400 error if not (S3 behaviour).
- delLifeCycle : remove the bucket lifecycle configuration (all rules).
- putLifeCycleRule : add a new lifecycle rule to the bucket lifecycle
  configuration. If the bucket hasn't lifecycle config, then create a
  new one.
- delLifeCycleRule : remove a lifecycle rule. If the rule is not found
  returns an error.
