### PR TITLE
Add delete to S3 subresources list to resolve `SignatureDoesNotMatch` Error

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -44,7 +44,8 @@ exports.subResource = {
 	versionId: null,
 	versioning: null,
 	versions: null,
-	website: null
+	website: null,
+	delete: null
 };
 /**
  * Canned ACLs


### PR DESCRIPTION
Add delete to S3 subresources list, which is for deleting multiple objects using a single POST request:
http://docs.amazonwebservices.com/AmazonS3/latest/API/multiobjectdeleteapi.html
