### PR TITLE
Fix s3.put truncation of utf8-encoded string

### DIFF
--- a/lib/internals.js
+++ b/lib/internals.js
@@ -126,7 +126,7 @@ var makeRequest = function (config, options, body, handler, callback, requestId)
 	if (body) {
 		switch (typeof body) {
 			case 'string':
-				options.headers['content-length'] = body.length;
+				options.headers['content-length'] = Buffer.byteLength(body);
 			break;
 			
 			case 'object':


### PR DESCRIPTION
When makeRequest calculates the content-length of a string, it doesn't
take the eventual utf8 encoding of that string into account. So if any
of the characters in the string expand out to multiple bytes in the utf8
encoding, the string will be truncated by that many characters.

The fix is to use Buffer.byteLength(string) to calculate the
content-length. It uses the same default utf8 encoding that
request.write(string) uses.
