### PR TITLE
Removing the npm module is killing the rebuild command.

### DIFF
--- a/install.js
+++ b/install.js
@@ -35,10 +35,10 @@ npm.load({}, function (err) {
 	var cleanup = function () {
 		if (finished.xml && finished.mime) {
 			// remove the bootstrapped npm for local installations
-			if (npm.config.get('global') === false) {
-				console.log('Removing the bootstrapped npm.');
-				npm.commands.uninstall(['npm']);
-			}
+//			if (npm.config.get('global') === false) {
+//				console.log('Removing the bootstrapped npm.');
+//				npm.commands.uninstall(['npm']);
+//			}
 			
 			// write the dependencies file in order to idicate to the internals which modules to use
 			console.log('Finished to install the dependencies. XML: %s; MIME: %s.', xmlMod, mimeMod);


### PR DESCRIPTION
I'm not sure what problems were being caused by leaving the npm module in the node_modules folder, but when you remove it, then any subsequent calls to 'npm rebuild' fail because they can't find 'npm' in the 'install.js' file.  Sadly, the default heroku buildpack for Nodejs projects does an 'npm install' followed by an 'npm rebuild' so my build dies everytime with the latest aws2js version.
