### PR TITLE
Don't error on close event 204

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -1189,7 +1189,7 @@ var client = function (config, httpOptions) {
 		/**
 		 * Exposes the deprecated escapePath() helper
 		 * 
-		 * @param {String} patho
+		 * @param {String} path
 		 * @returns {String}
 		 */
 		config.escapePath = tools.escapePath;

--- a/lib/internals.js
+++ b/lib/internals.js
@@ -824,7 +824,7 @@ var putLifeCycleConfig = function (config, lifecycle, callback) {
 	
 	md5.update(body);
 	headers['content-md5'] = md5.digest('base64');
-
+	
 	// put the new lifecycle configuration
 	config.put('?lifecycle', headers, body, callback);
 };


### PR DESCRIPTION
AWS reponds with an empty body and 204 response after removing something from S3. In some such cases we get the response close event: I don't think this should be an error if the response code is 204, as we already have all the data we're going to get. Hence this two line change.

As an aside, how do you recommend developing aws2js? I don't really understand how to check it out from github and run the tests: I think I'm missing some aspect of how npm modules work. Currently, I do something like

mkdir foo;cd foo
npm install lodash@0.8.2  libxmljs libxml-to-js http-get aws2js
cd node_modules; ./tools/test.sh

The tests run: but I'm not editing a git checkout, so at the end, I have to copy and paste changes into a checked out aws2js branch. I guess there must be some way to just checkout the code and run the tests in situ, but I can't work it out.

And advice would be gratefully received
- Dave
