### PR TITLE
Don't sign the Date header if the x-amz-date header is present

### DIFF
--- a/lib/internals.js
+++ b/lib/internals.js
@@ -522,7 +522,11 @@ var authorize = function (config, method, headers, path, query) {
 	if (headers['content-type']) {
 		toSign += headers['content-type'];
 	}
-	toSign += '\n' + headers.date + '\n';
+        toSign += '\n';
+	if (!headers['x-amz-date']) {
+                toSign += headers['date'];
+        }
+        toSign += '\n';
 	
 	var n, key, keys = [];
 	var sorted = {};


### PR DESCRIPTION
From http://s3.amazonaws.com/doc/s3-developer-guide/RESTAuthentication.html: 

"...Some toolkits make it difficult to manually set the date.  If you have trouble including the value of the 'Date' header in the canonicalized headers, you can include an 'x-amz-date' header prior to canonicalization.  The value of the x-amz-date header must be in one of the RFC 2616 formats (http://www.ietf.org/rfc/rfc2616.txt).  If S3 sees an x-amz-date header in the request, it will ignore the Date header when validating the request signature.  If you include the x-amz-date header, you must still include a newline character in the canonicalized string at the point where the Date value would normally be inserted...."

Hence this change. Works for me, at any rate ;)
