### PR TITLE
Do not silently return early if both content-type and content-length is specified.

### DIFF
--- a/lib/internals.js
+++ b/lib/internals.js
@@ -732,12 +732,12 @@ var standardHeaders = function (config, method, headers, path, body, callback) {
 				hdr['content-type'] = mimeDep.lookup(body.file);
 				contentLength(body.file, config, method, hdr, path, callback);
 			}
-		} else {
-			if ( ! hdr['content-length']) {
-				contentLength(body.file, config, method, hdr, path, callback);
-			}
+			return;
 		}
-		return;
+		if ( ! hdr['content-length']) {
+			contentLength(body.file, config, method, hdr, path, callback);
+			return;
+		}
 	}
 	
 	hdr.authorization = authorize(config, method, hdr, path);


### PR DESCRIPTION
Do not return early if both content-type and content-length is specified.

Calling putFile with both content-type and content-length headers would result in the upload never starting, and the callback never called.

I believe this was a bug introduced in 15e22278cc31.
