### PR TITLE
Fix s3.get(path, { file : somePath }) not closing file on error

### DIFF
--- a/lib/internals.js
+++ b/lib/internals.js
@@ -139,7 +139,7 @@ exports.filterByteRange = filterByteRange;
  */
 var makeRequest = function (config, options, body, handler, callback, requestId) {
 	var transfer = new EventEmitter();
-	var file, json, haveBodyHandler, bfile, error;
+	var file, json, haveBodyHandler, bfile, error, called;
 	
 	if (requestId === undefined) {
 		requestId = 0;
@@ -224,9 +224,12 @@ var makeRequest = function (config, options, body, handler, callback, requestId)
 			});
 			
 			file.on('close', function () {
-				callback(null, {
-					file: handler.file
-				});
+				// If there was an error and we have alraedy called callback
+				if (!called) {
+					callback(null, {
+						file: handler.file
+					});
+				}
 			});
 		} catch (err) {
 			callback(err);
@@ -267,16 +270,18 @@ var makeRequest = function (config, options, body, handler, callback, requestId)
 			parser(Buffer.concat(data).toString(), function (error, result) {
 				if (response.statusCode !== 200) {
 					error = new Error('API error with HTTP Code: ' + response.statusCode);
-					error.headers = response.headers;
-					error.code = response.statusCode;
 					if (result) {
 						error.document = result;
 					}
-					callback(error);
-				} else if (error) {
+				}
+				if (error) {
 					error.headers = response.headers;
 					error.code = response.statusCode;
+					if (file) {
+						file.destroy();
+					}
 					callback(error);
+					called = true;
 				} else {
 					callback(null, result);
 				}

--- a/tests/s3-get-with-error.js
+++ b/tests/s3-get-with-error.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var common = require('./includes/common.js');
+var assert = require('assert');
+var s3 = require('../').load('s3');
+var fs = require('fs');
+
+function wrap(name) {
+    var fn = fs[name];
+    wrap[name] = 0;
+    fs[name] = function () {
+        wrap[name]++
+        fn.apply(null, arguments);
+    };
+}
+
+wrap('close');
+wrap('open');
+
+var callbacks = {
+	get: 0
+};
+
+s3.setCredentials(process.env.AWS_ACCEESS_KEY_ID, process.env.AWS_SECRET_ACCESS_KEY);
+s3.setBucket(process.env.AWS2JS_S3_BUCKET);
+
+s3.get('SOME_FILE_THAT_DOESNT_EXIST', { file : 'meoww.txt' }, function () {
+    callbacks.get++;
+    assert.equal(wrap.close, wrap.open, 'Not all file descriptors are closed');
+});
+common.teardown(callbacks);


### PR DESCRIPTION
Closes #85

I used `called` variable here, because when calling destroy, it will end up calling `end` event of file, which will call the call the callback again without error, but that's not what we want.

I have tested this with node v0.8.25 and v0.10.13, and it passes the s3-get tests(as I mentioned, some tests fail without modifications on my system, aside those no failing tests).
